### PR TITLE
feat: 카테고리 드롭다운 컴포넌트 제작

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -13,6 +13,7 @@
         "next": "14.2.15",
         "react": "^18",
         "react-dom": "^18",
+        "react-icons": "^5.3.0",
         "zustand": "^5.0.0-rc.2"
       },
       "devDependencies": {
@@ -1546,6 +1547,14 @@
       },
       "peerDependencies": {
         "react": "^18.3.1"
+      }
+    },
+    "node_modules/react-icons": {
+      "version": "5.3.0",
+      "resolved": "https://registry.npmjs.org/react-icons/-/react-icons-5.3.0.tgz",
+      "integrity": "sha512-DnUk8aFbTyQPSkCfF8dbX6kQjXA9DktMeJqfjrg6cK9vwQVMxmcA3BfP4QoiztVmEHtwlTgLFsPuH2NskKT6eg==",
+      "peerDependencies": {
+        "react": "*"
       }
     },
     "node_modules/read-cache": {

--- a/package.json
+++ b/package.json
@@ -14,6 +14,7 @@
     "next": "14.2.15",
     "react": "^18",
     "react-dom": "^18",
+    "react-icons": "^5.3.0",
     "zustand": "^5.0.0-rc.2"
   },
   "devDependencies": {

--- a/src/components/@Shared/dropdown/Dropdown.tsx
+++ b/src/components/@Shared/dropdown/Dropdown.tsx
@@ -1,0 +1,50 @@
+import { useState } from 'react';
+import { HiChevronDown } from 'react-icons/hi';
+
+const categories = ['문화 예술', '식음료', '스포츠', '투어', '관광'];
+
+const Dropdown = () => {
+  const [isOpen, setIsOpen] = useState(false);
+  const [selectedCategory, setSelectedCategory] = useState<string | null>(null);
+
+  const toggleDropdown = () => setIsOpen(!isOpen);
+  const selectCategory = (category: string) => {
+    setSelectedCategory(category);
+    setIsOpen(false);
+  };
+
+  return (
+    <div className="relative w-[800px]">
+      <button
+        onClick={toggleDropdown}
+        className="w-full bg-white border border-gray-300 rounded-md px-4 py-3 text-left flex justify-between items-center"
+      >
+        <span className={selectedCategory ? 'text-black' : 'text-gray-500'}>
+          {selectedCategory || '카테고리'}
+        </span>
+        <HiChevronDown className="text-gray-400" />
+      </button>
+
+      {isOpen && (
+        <ul className="absolute z-10 w-full bg-white border border-gray-300 rounded-md mt-1 shadow-lg p-2">
+          {categories.map((category) => (
+            <li
+              key={category}
+              onClick={() => selectCategory(category)}
+              className={`cursor-pointer px-4 py-3 flex items-center rounded-md ${
+                selectedCategory === category
+                  ? 'bg-emerald-950 text-white'
+                  : 'hover:bg-gray-200'
+              }`}
+            >
+              {selectedCategory === category && <span className="mr-2">✔</span>}
+              {category}
+            </li>
+          ))}
+        </ul>
+      )}
+    </div>
+  );
+};
+
+export default Dropdown;


### PR DESCRIPTION
## 🔎 어떤 기능인가요?

> 카테고리 드롭다운 컴포넌트 제작

## 📋 작업 상세 내용

- [x] 삼항선택자로 선택된 항목의 배경색이 고정되어 선택된 항목은 호버해도 색상 유지
- [x] hover:bg-gray-200를 조건부로 체크되지 않은 항목에만 적용하여 체크되지 않은 항목에 호버 시 강조색이 적용되도록 변경

## 📌 참고 자료(선택)
![localhost_3000-Chrome-2024-10-14-13-05-19](https://github.com/user-attachments/assets/c843f82f-575c-49d2-b4bf-06ccd5fa9de9)


## ❗ 기타사항
