### PR TITLE
Feat: F81-45 체험등록페이지 작업

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -16,6 +16,7 @@
         "framer-motion": "^11.11.8",
         "next": "14.2.15",
         "react": "^18",
+        "react-daum-postcode": "^3.1.3",
         "react-dom": "^18",
         "react-icons": "^5.3.0",
         "zustand": "^5.0.0-rc.2"
@@ -1821,6 +1822,14 @@
       },
       "engines": {
         "node": ">=0.10.0"
+      }
+    },
+    "node_modules/react-daum-postcode": {
+      "version": "3.1.3",
+      "resolved": "https://registry.npmjs.org/react-daum-postcode/-/react-daum-postcode-3.1.3.tgz",
+      "integrity": "sha512-qTyzUb1BeszPFO4FXSj6p83Wrn5Zpo6YqI2EZ46XSVRZT+du9CrKg9p3KshBRFKYxXmFE1Mv7wEynzXdRFNlmQ==",
+      "peerDependencies": {
+        "react": ">=16.8.0"
       }
     },
     "node_modules/react-dom": {

--- a/package.json
+++ b/package.json
@@ -11,12 +11,13 @@
   "dependencies": {
     "@headlessui/react": "^2.1.10",
     "@tanstack/react-query": "^5.59.8",
-    "axios": "^1.7.7",
     "autoprefixer": "^10.4.20",
+    "axios": "^1.7.7",
     "flowbite": "^2.5.2",
     "framer-motion": "^11.11.8",
     "next": "14.2.15",
     "react": "^18",
+    "react-daum-postcode": "^3.1.3",
     "react-dom": "^18",
     "react-icons": "^5.3.0",
     "zustand": "^5.0.0-rc.2"

--- a/src/components/@Shared/dropdown/Dropdown.tsx
+++ b/src/components/@Shared/dropdown/Dropdown.tsx
@@ -14,7 +14,7 @@ const Dropdown = () => {
   };
 
   return (
-    <div className="relative w-[800px]">
+    <div className="relative w-full">
       <button
         onClick={toggleDropdown}
         className="w-full bg-white border border-gray-300 rounded-md px-4 py-3 text-left flex justify-between items-center"
@@ -31,9 +31,9 @@ const Dropdown = () => {
             <li
               key={category}
               onClick={() => selectCategory(category)}
-              className={`cursor-pointer px-4 py-3 flex items-center rounded-md ${
+              className={`cursor-pointer px-4 py-2 flex items-center rounded-md ${
                 selectedCategory === category
-                  ? 'bg-emerald-950 text-white'
+                  ? 'bg-nomadBlack text-white'
                   : 'hover:bg-gray-200'
               }`}
             >

--- a/src/pages/_document.tsx
+++ b/src/pages/_document.tsx
@@ -1,10 +1,16 @@
-import { Html, Head, Main, NextScript } from "next/document";
+// pages/_document.tsx
+import { Html, Head, Main, NextScript } from 'next/document';
 
 export default function Document() {
   return (
-    <Html lang="en">
-      <Head />
-      <body className="antialiased">
+    <Html>
+      <Head lang="en">
+        <script
+          src="https://t1.daumcdn.net/mapjsapi/bundle/postcode/prod/postcode.v2.js"
+          type="text/javascript"
+        ></script>
+      </Head>
+      <body>
         <Main />
         <NextScript />
       </body>

--- a/src/pages/myInfo/activites.tsx
+++ b/src/pages/myInfo/activites.tsx
@@ -1,0 +1,323 @@
+import React, { useState, useEffect } from 'react';
+import Category from '@/components/@Shared/dropDown/Dropdown';
+
+const ExperienceForm = () => {
+  const [availableTimes, setAvailableTimes] = useState([
+    { date: '', startTime: '', endTime: '' },
+  ]);
+
+  const [title, setTitle] = useState('');
+  const [category, setCategory] = useState('');
+  const [description, setDescription] = useState('');
+  const [price, setPrice] = useState('');
+  const [address, setAddress] = useState('');
+  const [postcode, setPostcode] = useState('');
+  const [bannerImages, setBannerImages] = useState<File[]>([]);
+  const [introImages, setIntroImages] = useState<File[]>([]);
+
+  // 예약 가능한 시간대 추가
+  const addAvailableTime = () => {
+    setAvailableTimes([
+      ...availableTimes,
+      { date: '', startTime: '', endTime: '' },
+    ]);
+  };
+
+  // 예약 가능한 시간대 삭제
+  const removeAvailableTime = (index: number) => {
+    const updatedTimes = [...availableTimes];
+    updatedTimes.splice(index, 1);
+    setAvailableTimes(updatedTimes);
+  };
+
+  // 시간대 변경
+  const handleTimeChange = (index: number, field: string, value: string) => {
+    const updatedTimes = [...availableTimes];
+    updatedTimes[index] = { ...updatedTimes[index], [field]: value };
+    setAvailableTimes(updatedTimes);
+  };
+
+  // 배너 이미지 업로드
+  const handleBannerImageChange = (e: React.ChangeEvent<HTMLInputElement>) => {
+    if (e.target.files && e.target.files.length > 0) {
+      setBannerImages([e.target.files[0]]);
+    }
+  };
+
+  // 배너 이미지 삭제
+  const removeBannerImage = () => {
+    setBannerImages([]);
+  };
+
+  // 소개 이미지 업로드
+  const handleIntroImagesChange = (e: React.ChangeEvent<HTMLInputElement>) => {
+    if (e.target.files) {
+      const newImages = Array.from(e.target.files);
+      if (introImages.length + newImages.length <= 4) {
+        setIntroImages([...introImages, ...newImages]);
+      } else {
+        alert('소개 이미지는 최대 4개까지 업로드할 수 있습니다.');
+      }
+    }
+  };
+
+  // 소개 이미지 삭제
+  const removeIntroImage = (index: number) => {
+    const updatedImages = [...introImages];
+    updatedImages.splice(index, 1);
+    setIntroImages(updatedImages);
+  };
+
+  useEffect(() => {
+    // Daum 우편번호 스크립트 동적추가
+    const script = document.createElement('script');
+    script.src =
+      '//t1.daumcdn.net/mapjsapi/bundle/postcode/prod/postcode.v2.js';
+    script.async = true;
+    document.body.appendChild(script);
+
+    return () => {
+      document.body.removeChild(script);
+    };
+  }, []);
+
+  const handlePostcode = () => {
+    new (window as any).daum.Postcode({
+      oncomplete: (data: any) => {
+        let fullAddress = data.address;
+        let extraAddress = '';
+
+        if (data.addressType === 'R') {
+          if (data.bname !== '') {
+            extraAddress += data.bname;
+          }
+          if (data.buildingName !== '') {
+            extraAddress +=
+              extraAddress !== ''
+                ? `, ${data.buildingName}`
+                : data.buildingName;
+          }
+          fullAddress += extraAddress !== '' ? ` (${extraAddress})` : '';
+        }
+
+        setAddress(fullAddress);
+        setPostcode(data.zonecode);
+      },
+    }).open();
+  };
+
+  const handleSubmit = (e: React.FormEvent) => {
+    e.preventDefault();
+    console.log({ title, category, description, price, address, postcode });
+  };
+
+  return (
+    <form onSubmit={handleSubmit} className="max-w-[796px] mx-auto">
+      <div className="flex justify-between items-center mb-6">
+        <h2 className="text-2xl font-bold">내 체험 등록</h2>
+        <button
+          type="submit"
+          className="w-[120px] p-2 bg-nomadBlack text-white rounded font-medium"
+        >
+          등록하기
+        </button>
+      </div>
+      <div className="mb-6">
+        <label className="block text-lg font-semibold mb-2">제목</label>
+        <input
+          type="text"
+          value={title}
+          onChange={(e) => setTitle(e.target.value)}
+          className="w-full p-2 border border-gray-300 rounded"
+          placeholder="제목을 입력하세요"
+        />
+      </div>
+
+      <div className="mb-6">
+        <label className="block text-lg font-semibold mb-2">카테고리</label>
+        <Category></Category>
+      </div>
+
+      <div className="mb-6">
+        <label className="block text-lg font-semibold mb-2">설명</label>
+        <textarea
+          value={description}
+          onChange={(e) => setDescription(e.target.value)}
+          className="w-full h-[346px] p-2 border border-gray-300 rounded"
+          placeholder="설명을 입력하세요"
+        />
+      </div>
+
+      <div className="mb-6">
+        <label className="block text-lg font-semibold mb-2">가격</label>
+        <input
+          type="text"
+          value={price}
+          onChange={(e) => setPrice(e.target.value)}
+          className="w-full p-2 border border-gray-300 rounded"
+          placeholder="가격을 입력하세요"
+        />
+      </div>
+
+      <div className="mb-6">
+        <label className="block text-lg font-semibold mb-2">우편번호</label>
+        <div className="flex">
+          <input
+            type="text"
+            value={postcode}
+            readOnly
+            className="w-full p-2 border border-gray-300 rounded mr-2"
+            placeholder="우편번호"
+          />
+          <button
+            type="button"
+            onClick={handlePostcode}
+            className="p-2 bg-green-200 text-white rounded w-[15%] hover:bg-green-950"
+          >
+            찾기
+          </button>
+        </div>
+      </div>
+
+      <div className="mb-6">
+        <label className="block text-lg font-semibold mb-2">주소</label>
+        <input
+          type="text"
+          value={address}
+          readOnly
+          className="w-full p-2 border border-gray-300 rounded"
+          placeholder="주소"
+        />
+      </div>
+
+      {/* 예약 가능한 시간대 */}
+      <div className="my-6">
+        <h3 className="text-lg font-semibold mb-2">예약 가능한 시간대</h3>
+        {availableTimes.map((time, index) => (
+          <div key={index} className="w-full flex items-center gap-5 mb-4">
+            <input
+              type="date"
+              value={time.date}
+              onChange={(e) => handleTimeChange(index, 'date', e.target.value)}
+              className="border p-2 rounded w-1/2"
+            />
+            <input
+              type="time"
+              value={time.startTime}
+              onChange={(e) =>
+                handleTimeChange(index, 'startTime', e.target.value)
+              }
+              className="border p-2 rounded w-1/4"
+            />
+            ~
+            <input
+              type="time"
+              value={time.endTime}
+              onChange={(e) =>
+                handleTimeChange(index, 'endTime', e.target.value)
+              }
+              className="border p-2 rounded w-1/4"
+            />
+            {index === 0 ? (
+              <button
+                type="button"
+                onClick={addAvailableTime}
+                className="text-white text-xl bg-green-200 rounded w-[8%] h-[44px] hover:bg-nomadBlack"
+              >
+                +
+              </button>
+            ) : (
+              <button
+                type="button"
+                onClick={() => removeAvailableTime(index)}
+                className="text-white text-xl bg-red-800 rounded w-[8%] h-[44px]"
+              >
+                -
+              </button>
+            )}
+          </div>
+        ))}
+      </div>
+
+      {/* 배너 이미지 */}
+      <div className="my-6">
+        <h3 className="text-lg font-semibold mb-2">배너 이미지</h3>
+        <div className="flex gap-4 flex-wrap">
+          {/* 이미지 등록 버튼 */}
+          <label className="border-dashed border-2 border-gray-300 w-[180px] h-[180px] flex flex-col justify-center items-center rounded-lg cursor-pointer">
+            <input
+              type="file"
+              accept="image/*"
+              onChange={handleBannerImageChange}
+              className="hidden"
+            />
+            <span className="text-gray-500 text-2xl font-semibold">+</span>
+            <span className="text-gray-500">이미지 등록</span>
+          </label>
+
+          {/* 등록된 배너 이미지 */}
+          {bannerImages.length > 0 && (
+            <div className="relative w-[180px] h-[180px]">
+              <img
+                src={URL.createObjectURL(bannerImages[0])}
+                alt="배너 이미지"
+                className="w-full h-full object-cover rounded-lg"
+              />
+              <button
+                type="button"
+                onClick={removeBannerImage}
+                className="absolute top-[-15px] right-[-15px] bg-black text-white rounded-full p-1 opacity-80 w-[40px] h-[40px] text-xl"
+              >
+                X
+              </button>
+            </div>
+          )}
+        </div>
+      </div>
+
+      {/* 소개 이미지 */}
+      <div className="my-6">
+        <h3 className="text-lg font-semibold mb-2">소개 이미지</h3>
+        <div className="flex gap-4 flex-wrap">
+          {/* 이미지 등록 버튼 */}
+          <label className="border-dashed border-2 border-gray-300 w-[180px] h-[180px] flex flex-col justify-center items-center rounded-lg cursor-pointer">
+            <input
+              type="file"
+              accept="image/*"
+              multiple
+              onChange={handleIntroImagesChange}
+              className="hidden"
+            />
+            <span className="text-gray-500 text-2xl font-semibold">+</span>
+            <span className="text-gray-500">이미지 등록</span>
+          </label>
+
+          {/* 등록된 소개 이미지들 */}
+          {introImages.map((image, index) => (
+            <div key={index} className="relative w-[180px] h-[180px]">
+              <img
+                src={URL.createObjectURL(image)}
+                alt={`소개 이미지 ${index + 1}`}
+                className="w-full h-full object-cover rounded-lg"
+              />
+              <button
+                type="button"
+                onClick={() => removeIntroImage(index)}
+                className="absolute top-[-15px] right-[-15px] bg-black text-white rounded-full p-1 opacity-80 w-[40px] h-[40px] text-xl"
+              >
+                X
+              </button>
+            </div>
+          ))}
+        </div>
+        {introImages.length >= 4 && (
+          <p className="text-red-500 mt-2">
+            *소개 이미지는 최대 4개까지만 등록 가능합니다.
+          </p>
+        )}
+      </div>
+    </form>
+  );
+};
+
+export default ExperienceForm;


### PR DESCRIPTION
## 🔎 어떤 기능인가요?

> 마이페이지의 체험등록 페이지 작업

## 📋 작업 상세 내용

- [x] 카테고리는 `문화 예술 | 식음료 | 스포츠 | 투어 | 관광 | 웰빙` 으로 제한하고 드롭 다운으로 선택 가능
- [x] 다음(Daum) 우편번호 서비스를 이용해 주소 입력
- [x] '+' 버튼을 누르면 예약 가능한 시간이 추가됩니다.
- [x] '-' 버튼을 누르면 예약 가능한 시간이 삭제됩니다.
- [x] 배너 이미지는 최대 1개 등록
- [x] 소개 이미지는 최대 4개까지 등록이 가능

## 📌 참고 자료(선택)
ex)스크린샷 및 구현영상
![localhost_3001-Chrome-2024-10-18-13-05-07](https://github.com/user-attachments/assets/6929aad9-ebd4-474b-8099-6d7d75694ae7)


## ❗ 기타사항
- 아직 제출폼의 정보를 백엔드로 보내는 작업은 하지 않았습니다.
- 공용 컴포넌트인 드롭다운의 css를 약간 수정하였습니다. 