### PR TITLE
Feat : F81-51-로그인 기능 구현 및 기타 작업

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -18,6 +18,7 @@
         "next": "14.2.15",
         "react": "^18",
         "react-dom": "^18",
+        "react-hook-form": "^7.53.0",
         "zustand": "^5.0.0-rc.2"
       },
       "devDependencies": {
@@ -1953,6 +1954,22 @@
       },
       "peerDependencies": {
         "react": "^18.3.1"
+      }
+    },
+    "node_modules/react-hook-form": {
+      "version": "7.53.0",
+      "resolved": "https://registry.npmjs.org/react-hook-form/-/react-hook-form-7.53.0.tgz",
+      "integrity": "sha512-M1n3HhqCww6S2hxLxciEXy2oISPnAzxY7gvwVPrtlczTM/1dDadXgUxDpHMrMTblDOcm/AXtXxHwZ3jpg1mqKQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/react-hook-form"
+      },
+      "peerDependencies": {
+        "react": "^16.8.0 || ^17 || ^18 || ^19"
       }
     },
     "node_modules/read-cache": {

--- a/package.json
+++ b/package.json
@@ -19,6 +19,7 @@
     "next": "14.2.15",
     "react": "^18",
     "react-dom": "^18",
+    "react-hook-form": "^7.53.0",
     "zustand": "^5.0.0-rc.2"
   },
   "devDependencies": {

--- a/src/apis/instance/axiosInstance.ts
+++ b/src/apis/instance/axiosInstance.ts
@@ -1,18 +1,15 @@
 import axios from 'axios';
 
 export const axiosInstance = axios.create({
-  baseURL: process.env.NEXT_PUBLIC_BASE_URL,
+  baseURL: `https://sp-globalnomad-api.vercel.app/8-1`,
 });
 
 axiosInstance.interceptors.request.use(
   (config) => {
-    const token = localStorage.getItem('userInfo');
+    const token = localStorage.getItem('accessToken');
 
-    if (token) {
-      const userInfo = JSON.parse(token);
-      const userInfoAccessToken = userInfo.accessToken;
-      config.headers.Authorization = `Bearer ${userInfoAccessToken}`;
-    }
+    if (token) config.headers.Authorization = `Bearer ${token}`;
+    
 
     return config;
   },

--- a/src/apis/instance/axiosInstance.ts
+++ b/src/apis/instance/axiosInstance.ts
@@ -7,9 +7,7 @@ export const axiosInstance = axios.create({
 axiosInstance.interceptors.request.use(
   (config) => {
     const token = localStorage.getItem('accessToken');
-
     if (token) config.headers.Authorization = `Bearer ${token}`;
-    
 
     return config;
   },

--- a/src/apis/myInfo/api.ts
+++ b/src/apis/myInfo/api.ts
@@ -15,7 +15,7 @@ export const fetchLoginTest = async ({
       email: userEmail,
       password: userPassword,
     });
-    localStorage.setItem('userInfo', JSON.stringify(response.data));
+    localStorage.setItem('accessToken', JSON.stringify(response.data));
     return response.data;
   } catch (error) {
     console.error(error);

--- a/src/components/@Shared/Buttons/Button.tsx
+++ b/src/components/@Shared/Buttons/Button.tsx
@@ -18,7 +18,7 @@ export const Button = ({
       {'bg-gray-600 text-white border-none': disabled},
       {'bg-nomadBlack text-white': variant === 'solid'},
       {'bg-white border border-nomadBlack text-nomadBlack': variant === 'line'},
-      
+
     )
   }
   {...props}
@@ -33,4 +33,5 @@ interface ButtonProps {
   disabled? : boolean,
   onClick? : ()=>{},
   className? : string,
+  type? : "button" | "reset" | "submit",
 }

--- a/src/components/@Shared/Buttons/Button.tsx
+++ b/src/components/@Shared/Buttons/Button.tsx
@@ -3,36 +3,38 @@ import clsx from "clsx";
 export const Button = ({
   label,
   variant,
-  disabled=false,
+  disabled = false,
   onClick,
   className,
   ...props
-}: ButtonProps ) => {
-  return(<button
-    disabled={disabled}
-    onClick={onClick}
-  className={
-    clsx(
-      className,
-      'h-[38px] rounded-[6px] text-14-700',
-      {'bg-gray-600 text-white border-none': disabled},
-      {'bg-nomadBlack text-white': variant === 'solid'},
-      {'bg-white border border-nomadBlack text-nomadBlack': variant === 'line'},
-
-    )
-  }
-  {...props}
-  >
-    {label}
-    <span>{`${disabled}`}</span>
-  </button>)
-}
+}: ButtonProps) => {
+  return (
+    <button
+      disabled={disabled}
+      onClick={onClick}
+      className={clsx(
+        className,
+        'h-[38px] rounded-[6px] text-14-700',
+        {
+          'bg-gray-600 text-white border-none': disabled, // disabled 상태일 때 우선 적용
+        },
+        !disabled && { // disabled가 아닐 때만 variant에 따라 클래스 적용
+          'bg-nomadBlack text-white': variant === 'solid',
+          'bg-white border border-nomadBlack text-nomadBlack': variant === 'line',
+        }
+      )}
+      {...props}
+    >
+      {label}
+    </button>
+  );
+};
 
 interface ButtonProps {
-  label : string,
-  variant : 'solid' | 'line', 
-  disabled? : boolean,
-  onClick? : ()=>{},
-  className? : string,
-  type? : "button" | "reset" | "submit",
+  label: string;
+  variant: 'solid' | 'line';
+  disabled?: boolean;
+  onClick?: () => void;
+  className?: string;
+  type?: "button" | "reset" | "submit";
 }

--- a/src/components/@Shared/Buttons/Button.tsx
+++ b/src/components/@Shared/Buttons/Button.tsx
@@ -19,8 +19,8 @@ export const Button = ({
           'bg-gray-600 text-white border-none': disabled, // disabled 상태일 때 우선 적용
         },
         !disabled && { // disabled가 아닐 때만 variant에 따라 클래스 적용
-          'bg-nomadBlack text-white': variant === 'solid',
-          'bg-white border border-nomadBlack text-nomadBlack': variant === 'line',
+          'bg-nomadBlack hover:bg-[#234223] text-white': variant === 'solid',
+          'bg-white border hover:bg-[#edf2ed] border-nomadBlack text-nomadBlack': variant === 'line',
         }
       )}
       {...props}

--- a/src/components/@Shared/Buttons/Button.tsx
+++ b/src/components/@Shared/Buttons/Button.tsx
@@ -24,6 +24,7 @@ export const Button = ({
   {...props}
   >
     {label}
+    <span>{`${disabled}`}</span>
   </button>)
 }
 

--- a/src/components/auth/AuthDtos.ts
+++ b/src/components/auth/AuthDtos.ts
@@ -1,0 +1,7 @@
+export interface signUpFormData {
+  email:string;
+  nickname: string;
+  password: string;
+}
+
+

--- a/src/components/auth/AuthDtos.ts
+++ b/src/components/auth/AuthDtos.ts
@@ -3,5 +3,7 @@ export interface signUpFormData {
   nickname: string;
   password: string;
 }
-
-
+export interface LoginFormData {
+  email: string;
+  password: string;
+}

--- a/src/components/auth/AuthDtos.ts
+++ b/src/components/auth/AuthDtos.ts
@@ -7,3 +7,7 @@ export interface LoginFormData {
   email: string;
   password: string;
 }
+
+export interface signUpFormDataWithRepeat extends signUpFormData {
+  'password-repeat' : string;
+}

--- a/src/components/auth/AuthInput.tsx
+++ b/src/components/auth/AuthInput.tsx
@@ -1,23 +1,27 @@
-import { FC } from "react";
+import { FC, InputHTMLAttributes } from "react";
+import { UseFormRegister, FieldErrors } from "react-hook-form";
 
-interface AuthInputProps {
-  label : string;
-  name : string;
+interface AuthInputProps extends InputHTMLAttributes<HTMLInputElement> {
+  label: string;
+  register: UseFormRegister<any>;
+  name: string;
+  validation? : object;
+  errors? : FieldErrors<any>;
 }
 
-const AuthInput : FC<AuthInputProps> = ({label, name})=> {
-  return(
-    <label htmlFor={name}
-    className="flex flex-col">
+const AuthInput: FC<AuthInputProps> = ({ label, register, name, validation, errors, ...props }) => {
+  return (
+    <label className="flex flex-col">
       {label}
-      <input 
-        id={name}
-        name={name}
+      <input
+        {...register(name, validation)}
         placeholder={`${label}를 입력해주세요.`}
+        {...props}
         className="h-[58px] bg-white text-gray-900 text-16-400 rounded-[6px] border border-gray-900"
       />
+      {errors?.[name]?.message && <span>{String(errors?.[name]?.message)}</span>}
     </label>
-  )
+  );
 }
 
 export default AuthInput;

--- a/src/components/auth/AuthInput.tsx
+++ b/src/components/auth/AuthInput.tsx
@@ -1,5 +1,6 @@
 import { FC, InputHTMLAttributes } from "react";
 import { UseFormRegister, FieldErrors } from "react-hook-form";
+import clsx from "clsx";
 
 interface AuthInputProps extends InputHTMLAttributes<HTMLInputElement> {
   label: string;
@@ -17,9 +18,16 @@ const AuthInput: FC<AuthInputProps> = ({ label, register, name, validation, erro
         {...register(name, validation)}
         placeholder={`${label}를 입력해주세요.`}
         {...props}
-        className="h-[58px] bg-white text-gray-900 text-16-400 rounded-[6px] border border-gray-900"
+        className={
+          clsx(
+            'h-[58px] bg-white text-gray-900 text-16-400 rounded-[6px] border border-gray-900',
+            {'border-red-200': errors?.[name]},
+          )
+        }
       />
-      {errors?.[name]?.message && <span>{String(errors?.[name]?.message)}</span>}
+      {errors?.[name]?.message && <span
+      className="text-12-400 text-red-200"
+      >{String(errors?.[name]?.message)}</span>}
     </label>
   );
 }

--- a/src/components/auth/LoginForm.tsx
+++ b/src/components/auth/LoginForm.tsx
@@ -1,24 +1,55 @@
-import { FC } from 'react';
+import { FC, useState } from 'react';
 import { Button } from "@/components/@Shared/Buttons/Button";
-import AuthInput from './AuthInput';
 import { useForm } from 'react-hook-form';
+import { axiosInstance } from '@/apis/instance/axiosInstance'; // axiosInstance import 추가
+import AuthInput from './AuthInput';
 import clsx from 'clsx';
+import { useRouter } from 'next/router'; // useRouter import 추가
+import createValidations from './Validations';
+import { LoginFormData } from './AuthDtos';
+
 
 const LoginForm: FC = () => {
-  const { register, handleSubmit } = useForm();
+  const { register, handleSubmit, watch, trigger, formState: { errors } } = useForm<LoginFormData>({ mode: 'onBlur' });
+  const [isButtonValid, setIsButtonValid] = useState<boolean>(false);
+  const router = useRouter(); // useRouter 훅 사용
+  const Validations = createValidations(watch('password'));
+
+  const handleBlur = async (name: keyof LoginFormData) => {
+    const result = await trigger(name); // 특정 필드만 검사
+    const allFieldsFilled = Object.values(watch()).every(value => value !== ""); // 모든 필드가 채워졌는지 체크
+    setIsButtonValid(result && allFieldsFilled); // 유효성 검사 결과와 필드 채워짐 여부에 따라 버튼 상태 업데이트
+  };
+
+  const onSubmit = async (data: LoginFormData) => {
+    try {
+      const response = await axiosInstance.post('/auth/login', data); // 로그인 API 요청
+      alert('로그인 성공: ' + JSON.stringify(response.data));
+      
+      const {accessToken, refreshToken } = response.data;
+      // 엑세스 토큰을 로컬 스토리지에 저장
+      localStorage.setItem('accessToken', accessToken);
+      localStorage.setItem('refreshToken', refreshToken);
+      router.push('/'); // 로그인 성공 후 홈 페이지로 이동
+    } catch (error) {
+      console.error('로그인 실패:', error);
+      alert('로그인 실패: 잘못된 이메일이나 비밀번호입니다.'); // 에러 메시지 표시
+    }
+  }
 
   return (
     <form
-      onSubmit={handleSubmit((data) => alert(JSON.stringify(data)))}
+      onSubmit={handleSubmit(onSubmit)}
       className={clsx(
         'mt-6 flex flex-col justify-center gap-7',
         'w-full',
-      )}>
-      <AuthInput label="이메일" register={register} name="email" />
-      <AuthInput label="비밀번호" register={register} name="password" />
-      <Button variant="solid" label="로그인 하기" type="submit" />
+      )}
+    >
+      <AuthInput label="이메일" register={register} name="email" validation={Validations.email} onBlur={() => handleBlur('email')} errors={errors} />
+      <AuthInput label="비밀번호" register={register} name="password" validation={Validations.password} onBlur={() => handleBlur('password')} errors={errors} />
+      <Button variant="solid" label="로그인 하기" type="submit" disabled={!isButtonValid} />
     </form>
   );
-}
+};
 
 export default LoginForm;

--- a/src/components/auth/LoginForm.tsx
+++ b/src/components/auth/LoginForm.tsx
@@ -1,21 +1,24 @@
 import { FC } from 'react';
 import { Button } from "@/components/@Shared/Buttons/Button";
 import AuthInput from './AuthInput';
+import { useForm } from 'react-hook-form';
 import clsx from 'clsx';
 
-const LoginForm : FC = ()=> {
-  return(
-      <form
-      className={
-        clsx(
-          'mt-6 flex flex-col justify-center align-center gap-7',
-          'w-full',
-        )}>
-        <AuthInput label="이메일" name="email" />
-        <AuthInput label="비밀번호" name="pw" />
-        <Button variant="solid" label="로그인 하기" />
+const LoginForm: FC = () => {
+  const { register, handleSubmit } = useForm();
+
+  return (
+    <form
+      onSubmit={handleSubmit((data) => alert(JSON.stringify(data)))}
+      className={clsx(
+        'mt-6 flex flex-col justify-center gap-7',
+        'w-full',
+      )}>
+      <AuthInput label="이메일" register={register} name="email" />
+      <AuthInput label="비밀번호" register={register} name="password" />
+      <Button variant="solid" label="로그인 하기" type="submit" />
     </form>
-  )
+  );
 }
 
 export default LoginForm;

--- a/src/components/auth/LoginForm.tsx
+++ b/src/components/auth/LoginForm.tsx
@@ -1,41 +1,57 @@
 import { FC, useState } from 'react';
 import { Button } from "@/components/@Shared/Buttons/Button";
 import { useForm } from 'react-hook-form';
-import { axiosInstance } from '@/apis/instance/axiosInstance'; // axiosInstance import 추가
+import { axiosInstance } from '@/apis/instance/axiosInstance';
 import AuthInput from './AuthInput';
 import clsx from 'clsx';
-import { useRouter } from 'next/router'; // useRouter import 추가
+
 import createValidations from './Validations';
 import { LoginFormData } from './AuthDtos';
+import Modal from './modal';
+import useModalClose from './modalClose';
+import axios from 'axios';
 
 
 const LoginForm: FC = () => {
   const { register, handleSubmit, watch, trigger, formState: { errors } } = useForm<LoginFormData>({ mode: 'onBlur' });
   const [isButtonValid, setIsButtonValid] = useState<boolean>(false);
-  const router = useRouter(); // useRouter 훅 사용
-  const Validations = createValidations(watch('password'));
+  const [ modalOpen, setModalOpen ] = useState<boolean>(false);
+  const [ modalMessage, setModalMessage ] = useState<string>('');
+  const [ isLoginSuccess, setIsLoginSuccess ] = useState<boolean>(true);
 
+  const Validations = createValidations(watch('password'));
+  const modalClose = useModalClose();
   const handleBlur = async (name: keyof LoginFormData) => {
-    const result = await trigger(name); // 특정 필드만 검사
-    const allFieldsFilled = Object.values(watch()).every(value => value !== ""); // 모든 필드가 채워졌는지 체크
-    setIsButtonValid(result && allFieldsFilled); // 유효성 검사 결과와 필드 채워짐 여부에 따라 버튼 상태 업데이트
+    const result = await trigger(name); 
+    const allFieldsFilled = Object.values(watch()).every(value => value !== ""); 
+    setIsButtonValid(result && allFieldsFilled);
   };
 
   const onSubmit = async (data: LoginFormData) => {
     try {
-      const response = await axiosInstance.post('/auth/login', data); // 로그인 API 요청
-      alert('로그인 성공: ' + JSON.stringify(response.data));
-      
+      const response = await axiosInstance.post('/auth/login', data);
+      console.log(response.data);
       const {accessToken, refreshToken } = response.data;
-      // 엑세스 토큰을 로컬 스토리지에 저장
+      
+      console.log(`엑세스토큰, 리프레시토큰 로컬스토리지에 저장`);
       localStorage.setItem('accessToken', accessToken);
       localStorage.setItem('refreshToken', refreshToken);
-      router.push('/'); // 로그인 성공 후 홈 페이지로 이동
+      
+      setIsLoginSuccess(true);
+      setModalMessage(`로그인 성공`);
+      setModalOpen(true);
+      
     } catch (error) {
-      console.error('로그인 실패:', error);
-      alert('로그인 실패: 잘못된 이메일이나 비밀번호입니다.'); // 에러 메시지 표시
+      if(axios.isAxiosError(error)){
+        console.error('로그인 실패:', error);
+        setIsLoginSuccess(false);
+        setModalMessage(error.response?.data.message);
+        setModalOpen(true);
+      }
     }
   }
+
+
 
   return (
     <form
@@ -45,6 +61,7 @@ const LoginForm: FC = () => {
         'w-full',
       )}
     >
+      <Modal isOpen={modalOpen} message={modalMessage} onClose={()=> modalClose({type: 'login', isSuccess : isLoginSuccess, setModalOpen})} />
       <AuthInput label="이메일" register={register} name="email" validation={Validations.email} onBlur={() => handleBlur('email')} errors={errors} />
       <AuthInput label="비밀번호" register={register} name="password" validation={Validations.password} onBlur={() => handleBlur('password')} errors={errors} />
       <Button variant="solid" label="로그인 하기" type="submit" disabled={!isButtonValid} />

--- a/src/components/auth/Modal.tsx
+++ b/src/components/auth/Modal.tsx
@@ -1,0 +1,24 @@
+import { Button } from "../@Shared/Buttons/Button";
+
+interface ModalProps {
+  title: string;
+  isOpen : boolean;
+  onClose : () => void;
+}
+
+const Modal = ({isOpen, title, onClose} : ModalProps) => {
+  
+  if (isOpen) {
+    return(
+    <div className="fixed inset-0 z-10 flex items-center justify-center h-screen bg-[#000000] bg-opacity-70">
+      <div className="w-96 h-48 z-20 bg-white border-black">
+        <h1>{title}</h1>
+      <Button label="닫기" variant="line" onClick={onClose} type="button" />
+      </div>
+    </div>
+  ) 
+} else return;
+  
+}
+
+export default Modal;

--- a/src/components/auth/Modal.tsx
+++ b/src/components/auth/Modal.tsx
@@ -1,19 +1,19 @@
 import { Button } from "../@Shared/Buttons/Button";
 
 interface ModalProps {
-  title: string;
+  message: string;
   isOpen : boolean;
   onClose : () => void;
 }
 
-const Modal = ({isOpen, title, onClose} : ModalProps) => {
+const Modal = ({isOpen, message, onClose} : ModalProps) => {
   
   if (isOpen) {
     return(
     <div className="fixed inset-0 z-10 flex items-center justify-center h-screen bg-[#000000] bg-opacity-70">
-      <div className="w-96 h-48 z-20 bg-white border-black">
-        <h1>{title}</h1>
-      <Button label="닫기" variant="line" onClick={onClose} type="button" />
+      <div className="gap-[20px] flex flex-col w-96 h-48 z-20 bg-white border-black rounded-lg text-16-500 p-6 justify-center items-center">
+        <h1>{message}</h1>
+      <Button label="닫기" variant="solid" onClick={onClose} type="button" className="w-[138px] h-[32px]" />
       </div>
     </div>
   ) 

--- a/src/components/auth/SignUpForm.tsx
+++ b/src/components/auth/SignUpForm.tsx
@@ -1,23 +1,70 @@
 import { FC } from 'react';
 import { Button } from "@/components/@Shared/Buttons/Button";
 import AuthInput from './AuthInput';
+import { useForm } from 'react-hook-form';
 import clsx from 'clsx';
 
-const SignUpForm : FC = ()=> {
-  return(
-      <form
-      className={
-        clsx(
-          'mt-6 flex flex-col justify-center align-center gap-7',
-          'w-full',
-        )}>
-        <AuthInput label="이메일" name="email" />
-        <AuthInput label="닉네임" name="nickname" />
-        <AuthInput label="비밀번호" name="pw" />
-        <AuthInput label="비밀번호 확인" name="pw-repeat" />
-        <Button variant="solid" label="회원가입 하기" />
+
+interface signUpFormData {
+  email:string;
+  nickname: string;
+  password: string;
+}
+
+const SignUpForm: FC = () => {
+  const { register, handleSubmit, watch, formState: { isSubmitting,errors} } = useForm<signUpFormData>({mode: 'onBlur'});
+  const passwordValue = watch('password');
+
+  const Validations = {
+    
+    email : {
+      required: "이메일은 필수 입력입니다.",
+      pattern: {
+      value: /^[^\s@]+@[^\s@]+\.[^\s@]+$/,
+      message: "이메일 형식에 맞지 않습니다."
+      }
+    },
+    
+    password : {
+      required: "비밀번호는 필수 입력입니다.",
+      minLength: {
+      value: 8,
+      message: "비밀번호는 8자 이상 입력해주세요."
+      }
+    },
+
+    nickname : {
+      required: "닉네임은 필수 입력입니다.",
+      maxLength: {
+      value: 10,
+      message: "닉네임은 10자 이하로 입력해주세요."
+      }
+    },
+
+    passwordRepeat : {
+      required: "비밀번호를 한 번 더 입력해주세요.",
+      validate : (value : string ) => value === passwordValue || "비밀번호가 일치하지 않습니다.",
+    }
+
+  }
+
+  return (
+    <form
+      onSubmit={handleSubmit(async (data) => {
+        await new Promise(r => setTimeout(r, 1000))
+        alert(JSON.stringify(data));
+      })}
+      className={clsx(
+        'mt-6 flex flex-col justify-center align-center gap-7',
+        'w-full',
+      )}>
+      <AuthInput label="이메일" register={register} name="email" validation={Validations.email} errors={errors} />
+      <AuthInput label="닉네임" register={register} name="nickname" validation={Validations.nickname} errors={errors}/>
+      <AuthInput label="비밀번호" register={register} name="password" validation={Validations.password} errors={errors} />
+      <AuthInput label="비밀번호 확인" register={register} name="password-repeat" validation={Validations.passwordRepeat} errors={errors} />
+      <Button variant="solid" label="회원가입 하기" type="submit"  />
     </form>
-  )
+  );
 }
 
 export default SignUpForm;

--- a/src/components/auth/SignUpForm.tsx
+++ b/src/components/auth/SignUpForm.tsx
@@ -1,12 +1,17 @@
 import { FC, useState } from 'react';
 import { Button } from "@/components/@Shared/Buttons/Button";
 import { useForm } from 'react-hook-form';
-import { signUpFormData } from './AuthDtos';
+import { signUpFormData, signUpFormDataWithRepeat } from './AuthDtos';
 import AuthInput from './AuthInput';
 import clsx from 'clsx';
 import createValidations from './Validations';
 import { axiosInstance } from '@/apis/instance/axiosInstance';
 import { useRouter } from 'next/router'; // useRouter import 추가
+
+
+type passwordRepeatType = {
+  "password-repeat" : string;
+}
 
 const SignUpForm: FC = () => {
   const { register, handleSubmit, watch, trigger, formState: { errors } } = useForm<signUpFormData>({ mode: 'onBlur' });
@@ -15,8 +20,8 @@ const SignUpForm: FC = () => {
 
   const Validations = createValidations(watch('password'));
 
-  const handleBlur = async (name: keyof signUpFormData) => {
-    const result = await trigger(name); // 특정 필드만 검사
+  const handleBlur = async (name: keyof Partial<signUpFormDataWithRepeat>) => {
+    const result = await trigger(name as any); // 특정 필드만 검사
     const allFieldsFilled = Object.values(watch()).every(value => value !== ""); // 모든 필드가 채워졌는지 체크
     setIsButtonValid(result && allFieldsFilled); // 유효성 검사 결과와 필드 채워짐 여부에 따라 버튼 상태 업데이트
   };
@@ -44,7 +49,7 @@ const SignUpForm: FC = () => {
       <AuthInput label="닉네임" register={register} name="nickname" validation={Validations.nickname} errors={errors} onBlur={() => handleBlur('nickname')} />
       <AuthInput label="비밀번호" register={register} name="password" validation={Validations.password} errors={errors} onBlur={() => handleBlur('password')} />
       <AuthInput label="비밀번호 확인" register={register} name="password-repeat" validation={Validations.passwordRepeat} errors={errors} onBlur={() => handleBlur('password-repeat')} />
-      <Button variant="solid" label="회원가입 하기" type="submit" disabled={!isButtonValid} />
+      <Button variant="line" label="회원가입 하기" type="submit" disabled={!isButtonValid} className="h-[48px]" />
     </form>
   );
 };

--- a/src/components/auth/SignUpForm.tsx
+++ b/src/components/auth/SignUpForm.tsx
@@ -1,70 +1,41 @@
-import { FC } from 'react';
+import { FC, useState } from 'react';
 import { Button } from "@/components/@Shared/Buttons/Button";
-import AuthInput from './AuthInput';
 import { useForm } from 'react-hook-form';
+import { signUpFormData } from './AuthDtos';
+import AuthInput from './AuthInput';
 import clsx from 'clsx';
-
-
-interface signUpFormData {
-  email:string;
-  nickname: string;
-  password: string;
-}
+import createValidations from './Validations';
 
 const SignUpForm: FC = () => {
-  const { register, handleSubmit, watch, formState: { isSubmitting,errors} } = useForm<signUpFormData>({mode: 'onBlur'});
-  const passwordValue = watch('password');
+  const { register, handleSubmit, watch , trigger, formState: { errors } } = useForm<signUpFormData>({ mode: 'onBlur' });
+  const [isButtonValid, setIsButtonValid] = useState<boolean>(false);
 
-  const Validations = {
-    
-    email : {
-      required: "이메일은 필수 입력입니다.",
-      pattern: {
-      value: /^[^\s@]+@[^\s@]+\.[^\s@]+$/,
-      message: "이메일 형식에 맞지 않습니다."
-      }
-    },
-    
-    password : {
-      required: "비밀번호는 필수 입력입니다.",
-      minLength: {
-      value: 8,
-      message: "비밀번호는 8자 이상 입력해주세요."
-      }
-    },
+  const Validations = createValidations(watch('password'));
 
-    nickname : {
-      required: "닉네임은 필수 입력입니다.",
-      maxLength: {
-      value: 10,
-      message: "닉네임은 10자 이하로 입력해주세요."
-      }
-    },
-
-    passwordRepeat : {
-      required: "비밀번호를 한 번 더 입력해주세요.",
-      validate : (value : string ) => value === passwordValue || "비밀번호가 일치하지 않습니다.",
-    }
-
-  }
+  // 폼 전체 유효성 검사 및 버튼 상태 업데이트
+  const handleBlur = async () => {
+    const result = await trigger();  // blur 시에만 유효성 검사
+    setIsButtonValid(result);        // 검사 결과에 따라 버튼 활성화 여부 결정
+  };
 
   return (
     <form
       onSubmit={handleSubmit(async (data) => {
-        await new Promise(r => setTimeout(r, 1000))
+        await new Promise(r => setTimeout(r, 1000));
         alert(JSON.stringify(data));
       })}
       className={clsx(
         'mt-6 flex flex-col justify-center align-center gap-7',
         'w-full',
-      )}>
-      <AuthInput label="이메일" register={register} name="email" validation={Validations.email} errors={errors} />
-      <AuthInput label="닉네임" register={register} name="nickname" validation={Validations.nickname} errors={errors}/>
-      <AuthInput label="비밀번호" register={register} name="password" validation={Validations.password} errors={errors} />
-      <AuthInput label="비밀번호 확인" register={register} name="password-repeat" validation={Validations.passwordRepeat} errors={errors} />
-      <Button variant="solid" label="회원가입 하기" type="submit"  />
+      )}
+    >
+      <AuthInput label="이메일" register={register} name="email" validation={Validations.email} errors={errors} onBlur={handleBlur} />
+      <AuthInput label="닉네임" register={register} name="nickname" validation={Validations.nickname} errors={errors} onBlur={handleBlur} />
+      <AuthInput label="비밀번호" register={register} name="password" validation={Validations.password} errors={errors} onBlur={handleBlur} />
+      <AuthInput label="비밀번호 확인" register={register} name="password-repeat" validation={Validations.passwordRepeat} errors={errors} onBlur={handleBlur} />
+      <Button variant="solid" label="회원가입 하기" type="submit" disabled={!isButtonValid} />
     </form>
   );
-}
+};
 
 export default SignUpForm;

--- a/src/components/auth/SignUpForm.tsx
+++ b/src/components/auth/SignUpForm.tsx
@@ -7,15 +7,11 @@ import clsx from 'clsx';
 import createValidations from './Validations';
 import { axiosInstance } from '@/apis/instance/axiosInstance';
 import { useRouter } from 'next/router'; // useRouter import 추가
-
-
-type passwordRepeatType = {
-  "password-repeat" : string;
-}
-
+import Modal from './modal';
 const SignUpForm: FC = () => {
   const { register, handleSubmit, watch, trigger, formState: { errors } } = useForm<signUpFormData>({ mode: 'onBlur' });
   const [isButtonValid, setIsButtonValid] = useState<boolean>(false);
+  const [modalOpen, setModalOpen ] = useState<boolean>(false);
   const router = useRouter(); // useRouter 훅 사용
 
   const Validations = createValidations(watch('password'));
@@ -38,6 +34,9 @@ const SignUpForm: FC = () => {
   }
 
   return (
+    <>
+    <button onClick={()=> {setModalOpen(true)}}>모달 생성</button>
+    <Modal isOpen={modalOpen} onClose={()=>setModalOpen(false)} title='테스트 모달' />
     <form
       onSubmit={handleSubmit(onSubmit)}
       className={clsx(
@@ -49,8 +48,9 @@ const SignUpForm: FC = () => {
       <AuthInput label="닉네임" register={register} name="nickname" validation={Validations.nickname} errors={errors} onBlur={() => handleBlur('nickname')} />
       <AuthInput label="비밀번호" register={register} name="password" validation={Validations.password} errors={errors} onBlur={() => handleBlur('password')} />
       <AuthInput label="비밀번호 확인" register={register} name="password-repeat" validation={Validations.passwordRepeat} errors={errors} onBlur={() => handleBlur('password-repeat')} />
-      <Button variant="line" label="회원가입 하기" type="submit" disabled={!isButtonValid} className="h-[48px]" />
+      <Button variant="solid" label="회원가입 하기" type="submit" disabled={!isButtonValid} className="h-[48px]" />
     </form>
+    </>
   );
 };
 

--- a/src/components/auth/SignUpForm.tsx
+++ b/src/components/auth/SignUpForm.tsx
@@ -6,19 +6,18 @@ import AuthInput from './AuthInput';
 import clsx from 'clsx';
 import createValidations from './Validations';
 import { axiosInstance } from '@/apis/instance/axiosInstance';
-import { useRouter } from 'next/router'; // useRouter import 추가
 import Modal from './modal';
 import axios from 'axios';
+import useModalClose from './modalClose';
 
 const SignUpForm: FC = () => {
   const { register, handleSubmit, watch, trigger, formState: { errors } } = useForm<signUpFormData>({ mode: 'onBlur' });
   const [ isButtonValid, setIsButtonValid ] = useState<boolean>(false);
   const [ modalOpen, setModalOpen ] = useState<boolean>(false);
   const [ modalMessage, setModalMessage ] = useState<string>('');
-  const [ isLoginSuccess, setIsLoginSuccess ] = useState<boolean>(true);
+  const [ isSignUpSuccess, setIsSignUpSuccess ] = useState<boolean>(true);
 
-  const router = useRouter();
-
+  const modalClose = useModalClose();
   const Validations = createValidations(watch('password'));
 
   const handleBlur = async (name: keyof Partial<signUpFormDataWithRepeat>) => {
@@ -29,8 +28,9 @@ const SignUpForm: FC = () => {
 
   const onSubmit = async (data: signUpFormData) => {
     try {
-      const response = await axiosInstance.post('/users', data); 
-      setIsLoginSuccess(true);
+      const response = await axiosInstance.post('/users', data);
+      console.log(response.data);
+      setIsSignUpSuccess(true);
       setModalMessage(`회원가입 성공`);
       setModalOpen(true);
      
@@ -38,24 +38,16 @@ const SignUpForm: FC = () => {
       if(axios.isAxiosError(error)){
         console.log(`error : `)
         console.log(error.response?.data.message);
-        setIsLoginSuccess(false);
+        setIsSignUpSuccess(false);
         setModalMessage(error.response?.data.message);
         setModalOpen(true);
       }
     }
   }
 
-  const modalClose = (type : string, isLoginSuccess : boolean )=> {
-    setModalOpen(false);
-    if(isLoginSuccess) {
-      if(type === 'login') router.push('/');
-      if(type === 'signUp') router.push('/login');
-    }
-  }
   return (
     <>
-
-    <Modal isOpen={modalOpen} onClose={()=>modalClose('signUp', isLoginSuccess) } message={modalMessage} />
+    <Modal isOpen={modalOpen} onClose={()=>modalClose({type : 'signUp', isSuccess :isSignUpSuccess, setModalOpen}) } message={modalMessage} />
     <form
       onSubmit={handleSubmit(onSubmit)}
       className={clsx(

--- a/src/components/auth/Validations.ts
+++ b/src/components/auth/Validations.ts
@@ -1,0 +1,35 @@
+
+const createValidations = (passwordValue : string)=> {
+  return {
+    email : {
+      required: "이메일은 필수 입력입니다.",
+      pattern: {
+      value: /^[^\s@]+@[^\s@]+\.[^\s@]+$/,
+      message: "이메일 형식에 맞지 않습니다."
+      }
+    },
+    
+    password : {
+      required: "비밀번호는 필수 입력입니다.",
+      minLength: {
+      value: 8,
+      message: "비밀번호는 8자 이상 입력해주세요."
+      }
+    },
+  
+    nickname : {
+      required: "닉네임은 필수 입력입니다.",
+      maxLength: {
+      value: 10,
+      message: "닉네임은 10자 이하로 입력해주세요."
+      }
+    },
+  
+    passwordRepeat : {
+      required: "비밀번호를 한 번 더 입력해주세요.",
+      validate : (value : string ) => value === passwordValue || "비밀번호가 일치하지 않습니다.",
+    }
+  }
+}
+
+export default createValidations;

--- a/src/components/auth/modalClose.ts
+++ b/src/components/auth/modalClose.ts
@@ -1,0 +1,23 @@
+import { useRouter } from 'next/router';
+
+interface ModalCloseProps {
+  type: 'login' | 'signUp';
+  isSuccess: boolean;
+  setModalOpen: React.Dispatch<React.SetStateAction<boolean>>;
+}
+
+const useModalClose = () => {
+  const router = useRouter();
+
+  const modalClose = ({ type, isSuccess, setModalOpen }: ModalCloseProps) => {
+    setModalOpen(false);
+    if (isSuccess) {
+      if (type === 'login') router.push('/');
+      if (type === 'signUp') router.push('/login');
+    }
+  };
+
+  return modalClose;
+};
+
+export default useModalClose;

--- a/src/pages/signup/index.tsx
+++ b/src/pages/signup/index.tsx
@@ -1,5 +1,5 @@
 import AuthContainer from "@/components/auth/AuthContainer";
-import AuthLogo from "@/components/auth/authLogo";
+import AuthLogo from "@/components/auth/AuthLogo";
 import SignUpForm from "@/components/auth/SignUpForm";
 
 const SignUp = ()=> {


### PR DESCRIPTION
## 🔎 어떤 기능인가요?

> 로그인 기능 구현 및 기타 작업

## 📋 작업 상세 내용
- [v] 로그인 기능 (로그인 성공시 `accessToken` 과 `refreshToken` 은 `localstorage` 에 저장)
- [v] 유효성 검사 (react-hook-form)
- [v] 제출버튼 비활성화 (react-hook-form > trigger 함수 활용)

- [v] `modalClose` & `리다이렉션` (모달창을 닫으면 로그인 회원가입을 판별해서 `리다이렉트`)
- [v] 정훈님이 만들어두신 `axiosInstance` 수정해서 활용 ( `refreshToken`과 스토리지 이름 통일을 위해 `localStorage` 이름 `userInfo` > `accessToken` 으로 변경)


- 기타작업
- [v] 공용 버튼 컴포넌트 `disabled` 시 `css` 적용 안되는 것 해결
- [v] 버튼 `hover` 시 임시 색상 변경 적용 (`variant` 마다 달라짐)
- [v] 공용 모달 구현
- 
## 📌 참고 자료(선택)
ex)스크린샷 및 구현영상
![image](https://github.com/user-attachments/assets/82d70f9a-cb52-4aa6-af4c-a8d008e32b15)
유효성 검사 및 제출버튼 비활성화

![image](https://github.com/user-attachments/assets/6c08e983-401d-4f53-b34e-1a32e69a1c06)
모달
## ❗ 기타사항
